### PR TITLE
aem-site-theme-builder bump from v5.1.1 to v5.2.0

### DIFF
--- a/theme/package-lock.json
+++ b/theme/package-lock.json
@@ -5,9 +5,9 @@
     "requires": true,
     "dependencies": {
         "@adobe/aem-site-theme-builder": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/@adobe/aem-site-theme-builder/-/aem-site-theme-builder-5.1.1.tgz",
-            "integrity": "sha512-iRnPH2/r96T4GIucFmq8+eJLSX5bsyvRWBjNredkDleWD3aiyEKXTQHl8yr1YhpOyoFTFKlUmnFREtm4gq9A/A==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/@adobe/aem-site-theme-builder/-/aem-site-theme-builder-5.2.0.tgz",
+            "integrity": "sha512-gCo45flGo3zvLHE2FAUGZOG3FvO2JG1iiFfi8+QLghI/d8DdIBVa9GnoQg497aKmAOL1sbMx4Gakf7n48NXKwA==",
             "dev": true,
             "requires": {
                 "browser-sync": "2.27.4",

--- a/theme/package.json
+++ b/theme/package.json
@@ -12,7 +12,7 @@
         "live": "npm-run-all -p compile proxy"
     },
     "devDependencies": {
-        "@adobe/aem-site-theme-builder": "5.1.1",
+        "@adobe/aem-site-theme-builder": "5.2.0",
         "autoprefixer": "^10.3.0",
         "browser-sync": "^2.26.13",
         "clean-webpack-plugin": "^3.0.0",


### PR DESCRIPTION
`aem-site-theme-builder` bump from `v5.1.1` to `v5.2.0`.

- fixes browsersync issues for live preview