### PR TITLE
Removed jcr:uuid from template content

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,6 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
 
-    if: github.ref == 'refs/heads/main'
-
     steps:
       - uses: actions/checkout@v2
 

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/de/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/de/.content.xml
@@ -12,7 +12,6 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="German"
-        jcr:uuid="e7d3726a-dd3c-4a2b-9661-f59f2061ce05"
         sling:resourceType="core/wcm/components/page/v2/page"
         facebookAppId="123456"
         pageTitle="My Site"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/de/article/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/de/article/.content.xml
@@ -8,7 +8,6 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Article"
-        jcr:uuid="4d702dd7-8c5f-4b54-b85f-6f87ade52ca6"
         sling:resourceType="core/wcm/components/page/v2/page"
         socialMedia="[facebook,pinterest]">
         <root

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/de/article/sample-article-1/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/de/article/sample-article-1/.content.xml
@@ -8,7 +8,6 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Sample Article 1"
-        jcr:uuid="ae43a95b-1d5c-4ef9-ac71-cd9fe8a23326"
         sling:resourceType="core/wcm/components/page/v2/page"
         socialMedia="[facebook,pinterest]">
         <root

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/de/article/sample-article-2/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/de/article/sample-article-2/.content.xml
@@ -8,7 +8,6 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Sample Article 2"
-        jcr:uuid="f8c14d66-0f96-46ca-bfa4-223b1ce7388c"
         sling:resourceType="core/wcm/components/page/v2/page"
         socialMedia="[facebook,pinterest]">
         <root

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/de/article/sample-article-3/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/de/article/sample-article-3/.content.xml
@@ -8,7 +8,6 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Sample Article 3"
-        jcr:uuid="79c11e0d-3249-4d13-b9ce-6adf88c65ad5"
         sling:resourceType="core/wcm/components/page/v2/page"
         socialMedia="[facebook,pinterest]">
         <root

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/de/article/sample-article-4/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/de/article/sample-article-4/.content.xml
@@ -8,7 +8,6 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Sample Article 4"
-        jcr:uuid="f1b4bfa4-7eb3-413e-b965-cf2e90428ea6"
         sling:resourceType="core/wcm/components/page/v2/page"
         socialMedia="[facebook,pinterest]">
         <root

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/de/contact-us/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/de/contact-us/.content.xml
@@ -7,7 +7,6 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Contact Us"
-        jcr:uuid="663e10d4-7005-49c3-ad52-073e7ccf98be"
         sling:resourceType="core/wcm/components/page/v2/page">
         <root
             jcr:primaryType="nt:unstructured"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/de/home/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/de/home/.content.xml
@@ -7,7 +7,6 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Home"
-        jcr:uuid="141e8a56-02dc-4284-b11f-bb76d379e27e"
         sling:resourceType="core/wcm/components/page/v2/page">
         <root
             jcr:primaryType="nt:unstructured"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/en/article/sample-article-1/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/en/article/sample-article-1/.content.xml
@@ -8,7 +8,6 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Sample Article 1"
-        jcr:uuid="7c1b775f-6eb1-4efa-beaf-783bb4530d34"
         sling:resourceType="core/wcm/components/page/v2/page"
         socialMedia="[facebook,pinterest]">
         <root

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/en/article/sample-article-2/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/en/article/sample-article-2/.content.xml
@@ -8,7 +8,6 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Sample Article 2"
-        jcr:uuid="7900928c-1727-4b12-bc73-8e88ce02f20f"
         sling:resourceType="core/wcm/components/page/v2/page"
         socialMedia="[facebook,pinterest]">
         <root

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/en/article/sample-article-3/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/en/article/sample-article-3/.content.xml
@@ -8,7 +8,6 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Sample Article 3"
-        jcr:uuid="a5964165-9833-4790-8b81-ee05ceeffbe9"
         sling:resourceType="core/wcm/components/page/v2/page"
         socialMedia="[facebook,pinterest]">
         <root

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/en/article/sample-article-4/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/en/article/sample-article-4/.content.xml
@@ -8,7 +8,6 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Sample Article 4"
-        jcr:uuid="113160db-24fa-47aa-9cf9-6fd1e112bd7b"
         sling:resourceType="core/wcm/components/page/v2/page"
         socialMedia="[facebook,pinterest]">
         <root

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/en/contact-us/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/en/contact-us/.content.xml
@@ -7,7 +7,6 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Contact Us"
-        jcr:uuid="b03de32b-0ead-4512-84bc-fd42a435a613"
         sling:resourceType="core/wcm/components/page/v2/page">
         <root
             jcr:primaryType="nt:unstructured"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/.content.xml
@@ -12,7 +12,6 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="French"
-        jcr:uuid="09663c0d-dda1-48eb-bb84-b40ac22469b9"
         sling:resourceType="core/wcm/components/page/v2/page"
         facebookAppId="123456"
         pageTitle="My Site"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/article/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/article/.content.xml
@@ -8,7 +8,6 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Article"
-        jcr:uuid="027fdaac-aec7-42a4-89e8-98ef07fdf9ae"
         sling:resourceType="core/wcm/components/page/v2/page"
         socialMedia="[facebook,pinterest]">
         <root

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/article/sample-article-1/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/article/sample-article-1/.content.xml
@@ -8,7 +8,6 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Sample Article 1"
-        jcr:uuid="24b9b3ff-2c57-4f02-b5ae-95a08d1cf267"
         sling:resourceType="core/wcm/components/page/v2/page"
         socialMedia="[facebook,pinterest]">
         <root

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/article/sample-article-2/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/article/sample-article-2/.content.xml
@@ -8,7 +8,6 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Sample Article 2"
-        jcr:uuid="a3282562-0de4-4ba5-9e99-4d34a7efa6c8"
         sling:resourceType="core/wcm/components/page/v2/page"
         socialMedia="[facebook,pinterest]">
         <root

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/article/sample-article-3/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/article/sample-article-3/.content.xml
@@ -8,7 +8,6 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Sample Article 3"
-        jcr:uuid="2884d7f3-ab5c-4d84-a7f5-33b74a5c0219"
         sling:resourceType="core/wcm/components/page/v2/page"
         socialMedia="[facebook,pinterest]">
         <root

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/article/sample-article-4/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/article/sample-article-4/.content.xml
@@ -8,7 +8,6 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Sample Article 4"
-        jcr:uuid="195a5c04-f97e-48e1-beac-bca809c5522b"
         sling:resourceType="core/wcm/components/page/v2/page"
         socialMedia="[facebook,pinterest]">
         <root

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/contact-us/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/contact-us/.content.xml
@@ -7,7 +7,6 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Contact Us"
-        jcr:uuid="afecb56c-f271-4f1b-8791-9644ea877f8b"
         sling:resourceType="core/wcm/components/page/v2/page">
         <root
             jcr:primaryType="nt:unstructured"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/home/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/home/.content.xml
@@ -7,7 +7,6 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Home"
-        jcr:uuid="04d09c0c-668b-422f-8d73-084eda56539b"
         sling:resourceType="core/wcm/components/page/v2/page">
         <root
             jcr:primaryType="nt:unstructured"

--- a/site/src/main/content/jcr_root/content/dam/aem-site-template-standard/Group 3458@2x.png/.content.xml
+++ b/site/src/main/content/jcr_root/content/dam/aem-site-template-standard/Group 3458@2x.png/.content.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:tiff="http://ns.adobe.com/tiff/1.0/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dam="http://www.day.com/dam/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:mix="http://www.jcp.org/jcr/mix/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:mixinTypes="[mix:referenceable]"
-    jcr:primaryType="dam:Asset"
-    jcr:uuid="b1c86ca2-4f42-419b-8131-5365fc6b1fcd">
+    jcr:primaryType="dam:Asset">
     <jcr:content
         dam:assetState="processed"
         dam:processingId="acd5400b-7a39-45ee-bb9d-a23b33054612"

--- a/site/src/main/content/jcr_root/content/dam/aem-site-template-standard/Image@2x.png/.content.xml
+++ b/site/src/main/content/jcr_root/content/dam/aem-site-template-standard/Image@2x.png/.content.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:tiff="http://ns.adobe.com/tiff/1.0/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dam="http://www.day.com/dam/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:mix="http://www.jcp.org/jcr/mix/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:mixinTypes="[mix:referenceable]"
-    jcr:primaryType="dam:Asset"
-    jcr:uuid="54e3b0ba-40a8-4524-b502-72a6fc2fb099">
+    jcr:primaryType="dam:Asset">
     <jcr:content
         dam:assetState="processed"
         dam:processingId="242ed9c2-a5a0-42e2-8842-342d97e8fd41"

--- a/site/src/main/content/jcr_root/content/dam/aem-site-template-standard/building_large.png/.content.xml
+++ b/site/src/main/content/jcr_root/content/dam/aem-site-template-standard/building_large.png/.content.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:tiff="http://ns.adobe.com/tiff/1.0/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dam="http://www.day.com/dam/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:mix="http://www.jcp.org/jcr/mix/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:mixinTypes="[mix:referenceable]"
-    jcr:primaryType="dam:Asset"
-    jcr:uuid="42da45e4-ab2c-4e16-baa7-9cc6b64ce635">
+    jcr:primaryType="dam:Asset">
     <jcr:content
         dam:assetState="processed"
         dam:processingId="28e4fb6f-70b0-4750-ab41-6fdd83ed2a85"


### PR DESCRIPTION
Templates are designed to seed multiple sites with the same content and keeping these will lead to conflicting ids.

