### PR TITLE
[Sites30][Template] Update standard-template to latest version of the core components

### DIFF
--- a/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/policies/.content.xml
+++ b/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/policies/.content.xml
@@ -7,7 +7,7 @@
         <wcm jcr:primaryType="nt:unstructured">
             <components jcr:primaryType="nt:unstructured">
                 <page jcr:primaryType="nt:unstructured">
-                    <v2 jcr:primaryType="nt:unstructured">
+                    <v3 jcr:primaryType="nt:unstructured">
                         <page jcr:primaryType="nt:unstructured">
                             <policy_default
                                 cq:styleDefaultClasses="generic-page"
@@ -15,7 +15,7 @@
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Generic Page"
                                 sling:resourceType="wcm/core/components/policy/policy"
-                                clientlibs="[core.wcm.components.accordion.v1,core.wcm.components.tabs.v1,core.wcm.components.carousel.v1,core.wcm.components.image.v2,core.wcm.components.breadcrumb.v2,core.wcm.components.search.v1,core.wcm.components.form.text.v2,core.wcm.components.pdfviewer.v1,core.wcm.components.commons.datalayer.v1]">
+                                clientlibs="[core.wcm.components.accordion.v1,core.wcm.components.tabs.v1,core.wcm.components.carousel.v1,core.wcm.components.image.v3,core.wcm.components.breadcrumb.v2,core.wcm.components.search.v1,core.wcm.components.form.text.v2,core.wcm.components.pdfviewer.v1,core.wcm.components.commons.datalayer.v1]">
                                 <jcr:content jcr:primaryType="nt:unstructured"/>
                             </policy_default>
                             <policy_contact_us
@@ -24,7 +24,7 @@
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Contact Us"
                                 sling:resourceType="wcm/core/components/policy/policy"
-                                clientlibs="[core.wcm.components.accordion.v1,core.wcm.components.tabs.v1,core.wcm.components.carousel.v1,core.wcm.components.image.v2,core.wcm.components.breadcrumb.v2,core.wcm.components.search.v1,core.wcm.components.form.text.v2,core.wcm.components.pdfviewer.v1,core.wcm.components.commons.datalayer.v1]">
+                                clientlibs="[core.wcm.components.accordion.v1,core.wcm.components.tabs.v1,core.wcm.components.carousel.v1,core.wcm.components.image.v3,core.wcm.components.breadcrumb.v2,core.wcm.components.search.v1,core.wcm.components.form.text.v2,core.wcm.components.pdfviewer.v1,core.wcm.components.commons.datalayer.v1]">
                                 <jcr:content jcr:primaryType="nt:unstructured"/>
                             </policy_contact_us>
                             <policy_article
@@ -33,7 +33,7 @@
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Article Page"
                                 sling:resourceType="wcm/core/components/policy/policy"
-                                clientlibs="[core.wcm.components.accordion.v1,core.wcm.components.tabs.v1,core.wcm.components.carousel.v1,core.wcm.components.image.v2,core.wcm.components.breadcrumb.v2,core.wcm.components.search.v1,core.wcm.components.form.text.v2,core.wcm.components.pdfviewer.v1,core.wcm.components.commons.datalayer.v1]">
+                                clientlibs="[core.wcm.components.accordion.v1,core.wcm.components.tabs.v1,core.wcm.components.carousel.v1,core.wcm.components.image.v3,core.wcm.components.breadcrumb.v2,core.wcm.components.search.v1,core.wcm.components.form.text.v2,core.wcm.components.pdfviewer.v1,core.wcm.components.commons.datalayer.v1]">
                                 <jcr:content jcr:primaryType="nt:unstructured"/>
                             </policy_article>
                             <policy_home
@@ -41,14 +41,14 @@
                                 jcr:primaryType="nt:unstructured"
                                 jcr:title="Home page"
                                 sling:resourceType="wcm/core/components/policy/policy"
-                                clientlibs="[core.wcm.components.accordion.v1,core.wcm.components.tabs.v1,core.wcm.components.carousel.v1,core.wcm.components.image.v2,core.wcm.components.breadcrumb.v2,core.wcm.components.search.v1,core.wcm.components.form.text.v2,core.wcm.components.pdfviewer.v1,core.wcm.components.commons.datalayer.v1]">
+                                clientlibs="[core.wcm.components.accordion.v1,core.wcm.components.tabs.v1,core.wcm.components.carousel.v1,core.wcm.components.image.v3,core.wcm.components.breadcrumb.v2,core.wcm.components.search.v1,core.wcm.components.form.text.v2,core.wcm.components.pdfviewer.v1,core.wcm.components.commons.datalayer.v1]">
                                 <jcr:content jcr:primaryType="nt:unstructured"/>
                             </policy_home>
                         </page>
-                    </v2>
+                    </v3>
                 </page>
                 <download jcr:primaryType="nt:unstructured">
-                    <v1 jcr:primaryType="nt:unstructured">
+                    <v2 jcr:primaryType="nt:unstructured">
                         <download jcr:primaryType="nt:unstructured">
                             <policy_default
                                 jcr:description="Sets the title size to H3."
@@ -63,10 +63,10 @@
                                 <jcr:content jcr:primaryType="nt:unstructured"/>
                             </policy_default>
                         </download>
-                    </v1>
+                    </v2>
                 </download>
                 <teaser jcr:primaryType="nt:unstructured">
-                    <v1 jcr:primaryType="nt:unstructured">
+                    <v2 jcr:primaryType="nt:unstructured">
                         <teaser jcr:primaryType="nt:unstructured">
                             <policy_default
                                 jcr:description="Sets the title size to H3."
@@ -112,7 +112,7 @@
                                 </cq:styleGroups>
                             </policy_default>
                         </teaser>
-                    </v1>
+                    </v2>
                 </teaser>
                 <container jcr:primaryType="nt:unstructured">
                     <v1 jcr:primaryType="nt:unstructured">
@@ -131,13 +131,13 @@
                                             assetGroup="media"
                                             assetMimetype="image/*"
                                             droptarget="image"
-                                            resourceType="core/wcm/components/image/v2/image"/>
+                                            resourceType="core/wcm/components/image/v3/image"/>
                                         <mapping_1575030843388
                                             jcr:primaryType="nt:unstructured"
                                             assetGroup="content"
                                             assetMimetype="text/html"
                                             droptarget="experiencefragment"
-                                            resourceType="core/wcm/components/experiencefragment/v1/experiencefragment"/>
+                                            resourceType="core/wcm/components/experiencefragment/v2/experiencefragment"/>
                                         <mapping_1575030853128
                                             jcr:primaryType="nt:unstructured"
                                             assetGroup="media"
@@ -163,13 +163,13 @@
                                             assetGroup="media"
                                             assetMimetype="image/*"
                                             droptarget="image"
-                                            resourceType="core/wcm/components/image/v2/image"/>
+                                            resourceType="core/wcm/components/image/v3/image"/>
                                         <mapping_1575030260142
                                             jcr:primaryType="nt:unstructured"
                                             assetGroup="content"
                                             assetMimetype="text/html"
                                             droptarget="experiencefragment"
-                                            resourceType="core/wcm/components/experiencefragment/v1/experiencefragment"/>
+                                            resourceType="core/wcm/components/experiencefragment/v2/experiencefragment"/>
                                         <mapping_1575030269139
                                             jcr:primaryType="nt:unstructured"
                                             assetGroup="media"
@@ -232,13 +232,13 @@
                                             assetGroup="media"
                                             assetMimetype="image/*"
                                             droptarget="image"
-                                            resourceType="core/wcm/components/image/v2/image"/>
+                                            resourceType="core/wcm/components/image/v3/image"/>
                                         <mapping_1575030843388
                                             jcr:primaryType="nt:unstructured"
                                             assetGroup="content"
                                             assetMimetype="text/html"
                                             droptarget="experiencefragment"
-                                            resourceType="core/wcm/components/experiencefragment/v1/experiencefragment"/>
+                                            resourceType="core/wcm/components/experiencefragment/v2/experiencefragment"/>
                                         <mapping_1575030853128
                                             jcr:primaryType="nt:unstructured"
                                             assetGroup="media"
@@ -252,7 +252,7 @@
                     </v1>
                 </container>
                 <experiencefragment jcr:primaryType="nt:unstructured">
-                    <v1 jcr:primaryType="nt:unstructured">
+                    <v2 jcr:primaryType="nt:unstructured">
                         <experiencefragment jcr:primaryType="nt:unstructured">
                             <policy_header
                                 cq:styleDefaultClasses="header"
@@ -271,10 +271,10 @@
                                 <jcr:content jcr:primaryType="nt:unstructured"/>
                             </policy_footer>
                         </experiencefragment>
-                    </v1>
+                    </v2>
                 </experiencefragment>
                 <title jcr:primaryType="nt:unstructured">
-                    <v2 jcr:primaryType="nt:unstructured">
+                    <v3 jcr:primaryType="nt:unstructured">
                         <title jcr:primaryType="nt:unstructured">
                             <policy_page
                                 cq:styleDefaultClasses="h1_style"
@@ -350,7 +350,7 @@
                                 </cq:styleGroups>
                             </policy_default>
                         </title>
-                    </v2>
+                    </v3>
                 </title>
                 <text jcr:primaryType="nt:unstructured">
                     <v2 jcr:primaryType="nt:unstructured">
@@ -446,7 +446,7 @@
                     </v2>
                 </text>
                 <image jcr:primaryType="nt:unstructured">
-                    <v2 jcr:primaryType="nt:unstructured">
+                    <v3 jcr:primaryType="nt:unstructured">
                         <image jcr:primaryType="nt:unstructured">
                             <policy_default
                                 cq:styleDefaultClasses="standard"
@@ -514,10 +514,10 @@
                                 </cq:styleGroups>
                             </policy_default>
                         </image>
-                    </v2>
+                    </v3>
                 </image>
                 <languagenavigation jcr:primaryType="nt:unstructured">
-                    <v1 jcr:primaryType="nt:unstructured">
+                    <v2 jcr:primaryType="nt:unstructured">
                         <languagenavigation jcr:primaryType="nt:unstructured">
                             <policy_xf
                                 jcr:primaryType="nt:unstructured"
@@ -528,7 +528,7 @@
                                 <jcr:content jcr:primaryType="nt:unstructured"/>
                             </policy_xf>
                         </languagenavigation>
-                    </v1>
+                    </v2>
                 </languagenavigation>
                 <form jcr:primaryType="nt:unstructured">
                     <container jcr:primaryType="nt:unstructured">
@@ -578,7 +578,7 @@
                     </v1>
                 </separator>
                 <breadcrumb jcr:primaryType="nt:unstructured">
-                    <v2 jcr:primaryType="nt:unstructured">
+                    <v3 jcr:primaryType="nt:unstructured">
                         <breadcrumb jcr:primaryType="nt:unstructured">
                             <policy_default
                                 cq:styleDefaultClasses="standard"
@@ -605,10 +605,10 @@
                                 </cq:styleGroups>
                             </policy_default>
                         </breadcrumb>
-                    </v2>
+                    </v3>
                 </breadcrumb>
                 <button jcr:primaryType="nt:unstructured">
-                    <v1 jcr:primaryType="nt:unstructured">
+                    <v2 jcr:primaryType="nt:unstructured">
                         <button jcr:primaryType="nt:unstructured">
                             <policy_default
                                 cq:styleDefaultClasses="call-to-action"
@@ -651,7 +651,7 @@
                                 </cq:styleGroups>
                             </policy_default>
                         </button>
-                    </v1>
+                    </v2>
                 </button>
                 <tabs jcr:primaryType="nt:unstructured">
                     <v1 jcr:primaryType="nt:unstructured">
@@ -695,7 +695,7 @@
                         jcr:primaryType="nt:unstructured"
                         jcr:title="XF page"
                         sling:resourceType="wcm/core/components/policy/policy"
-                        clientlibs="[core.wcm.components.accordion.v1,core.wcm.components.tabs.v1,core.wcm.components.carousel.v1,core.wcm.components.image.v2,core.wcm.components.breadcrumb.v2,core.wcm.components.search.v1,core.wcm.components.form.text.v2,core.wcm.components.pdfviewer.v1,core.wcm.components.commons.datalayer.v1]">
+                        clientlibs="[core.wcm.components.accordion.v1,core.wcm.components.tabs.v1,core.wcm.components.carousel.v1,core.wcm.components.image.v3,core.wcm.components.breadcrumb.v2,core.wcm.components.search.v1,core.wcm.components.form.text.v2,core.wcm.components.pdfviewer.v1,core.wcm.components.commons.datalayer.v1]">
                         <jcr:content jcr:primaryType="nt:unstructured"/>
                     </policy_default>
                 </xfpage>

--- a/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/template-types/page/initial/.content.xml
+++ b/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/template-types/page/initial/.content.xml
@@ -3,7 +3,7 @@
     jcr:primaryType="cq:Page">
     <jcr:content
         jcr:primaryType="cq:PageContent"
-        sling:resourceType="core/wcm/components/page/v2/page">
+        sling:resourceType="core/wcm/components/page/v3/page">
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="core/wcm/components/container/v1/container">

--- a/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/template-types/page/policies/.content.xml
+++ b/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/template-types/page/policies/.content.xml
@@ -2,7 +2,7 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:primaryType="cq:Page">
     <jcr:content
-        cq:policy="core/wcm/components/page/v2/page/policy_default"
+        cq:policy="core/wcm/components/page/v3/page/policy_default"
         jcr:primaryType="nt:unstructured"
         sling:resourceType="wcm/core/components/policies/mappings">
         <root

--- a/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/template-types/page/structure/.content.xml
+++ b/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/template-types/page/structure/.content.xml
@@ -4,7 +4,7 @@
     <jcr:content
         cq:deviceGroups="[mobile/groups/responsive]"
         jcr:primaryType="cq:PageContent"
-        sling:resourceType="core/wcm/components/page/v2/page">
+        sling:resourceType="core/wcm/components/page/v3/page">
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="core/wcm/components/container/v1/container"

--- a/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/template-types/xf/policies/.content.xml
+++ b/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/template-types/xf/policies/.content.xml
@@ -2,7 +2,7 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:primaryType="cq:Page">
     <jcr:content
-        cq:policy="core/wcm/components/page/v2/page/policy_default"
+        cq:policy="core/wcm/components/page/v3/page/policy_default"
         jcr:primaryType="nt:unstructured"
         sling:resourceType="wcm/core/components/policies/mappings">
         <root

--- a/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/article-page/initial/.content.xml
+++ b/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/article-page/initial/.content.xml
@@ -4,7 +4,7 @@
     <jcr:content
         cq:template="/conf/aem-site-template-standard/settings/wcm/templates/article-page"
         jcr:primaryType="cq:PageContent"
-        sling:resourceType="core/wcm/components/page/v2/page">
+        sling:resourceType="core/wcm/components/page/v3/page">
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="core/wcm/components/container/v1/container">

--- a/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/article-page/policies/.content.xml
+++ b/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/article-page/policies/.content.xml
@@ -2,7 +2,7 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:primaryType="cq:Page">
     <jcr:content
-        cq:policy="core/wcm/components/page/v2/page/policy_article"
+        cq:policy="core/wcm/components/page/v3/page/policy_article"
         jcr:primaryType="nt:unstructured"
         sling:resourceType="wcm/core/components/policies/mappings">
         <root
@@ -21,12 +21,12 @@
                         <wcm jcr:primaryType="nt:unstructured">
                             <components jcr:primaryType="nt:unstructured">
                                 <title jcr:primaryType="nt:unstructured">
-                                    <v2 jcr:primaryType="nt:unstructured">
+                                    <v3 jcr:primaryType="nt:unstructured">
                                         <title
-                                            cq:policy="core/wcm/components/title/v2/title/policy_default"
+                                            cq:policy="core/wcm/components/title/v3/title/policy_default"
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="wcm/core/components/policies/mapping"/>
-                                    </v2>
+                                    </v3>
                                 </title>
                                 <text jcr:primaryType="nt:unstructured">
                                     <v2 jcr:primaryType="nt:unstructured">
@@ -37,12 +37,12 @@
                                     </v2>
                                 </text>
                                 <teaser jcr:primaryType="nt:unstructured">
-                                    <v1 jcr:primaryType="nt:unstructured">
+                                    <v2 jcr:primaryType="nt:unstructured">
                                         <teaser
-                                            cq:policy="core/wcm/components/teaser/v1/teaser/policy_default"
+                                            cq:policy="core/wcm/components/teaser/v2/teaser/policy_default"
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="wcm/core/components/policies/mapping"/>
-                                    </v1>
+                                    </v2>
                                 </teaser>
                                 <separator jcr:primaryType="nt:unstructured">
                                     <v1 jcr:primaryType="nt:unstructured">
@@ -53,12 +53,12 @@
                                     </v1>
                                 </separator>
                                 <image jcr:primaryType="nt:unstructured">
-                                    <v2 jcr:primaryType="nt:unstructured">
+                                    <v3 jcr:primaryType="nt:unstructured">
                                         <image
-                                            cq:policy="core/wcm/components/image/v2/image/policy_default"
+                                            cq:policy="core/wcm/components/image/v3/image/policy_default"
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="wcm/core/components/policies/mapping"/>
-                                    </v2>
+                                    </v3>
                                 </image>
                                 <tabs jcr:primaryType="nt:unstructured">
                                     <v1 jcr:primaryType="nt:unstructured">
@@ -69,40 +69,40 @@
                                     </v1>
                                 </tabs>
                                 <button jcr:primaryType="nt:unstructured">
-                                    <v1 jcr:primaryType="nt:unstructured">
-                                        <button
-                                            cq:policy="core/wcm/components/button/v1/button/policy_default"
-                                            jcr:primaryType="nt:unstructured"
-                                            sling:resourceType="wcm/core/components/policies/mapping"/>
-                                    </v1>
-                                </button>
-                                <breadcrumb jcr:primaryType="nt:unstructured">
                                     <v2 jcr:primaryType="nt:unstructured">
-                                        <breadcrumb
-                                            cq:policy="core/wcm/components/breadcrumb/v2/breadcrumb/policy_default"
+                                        <button
+                                            cq:policy="core/wcm/components/button/v2/button/policy_default"
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="wcm/core/components/policies/mapping"/>
                                     </v2>
+                                </button>
+                                <breadcrumb jcr:primaryType="nt:unstructured">
+                                    <v3 jcr:primaryType="nt:unstructured">
+                                        <breadcrumb
+                                            cq:policy="core/wcm/components/breadcrumb/v3/breadcrumb/policy_default"
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="wcm/core/components/policies/mapping"/>
+                                    </v3>
                                 </breadcrumb>
                             </components>
                         </wcm>
                     </core>
                 </container>
                 <title
-                    cq:policy="core/wcm/components/title/v2/title/policy_page"
+                    cq:policy="core/wcm/components/title/v3/title/policy_page"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="wcm/core/components/policies/mapping"/>
                 <breadcrumb
-                    cq:policy="core/wcm/components/breadcrumb/v2/breadcrumb/policy_default"
+                    cq:policy="core/wcm/components/breadcrumb/v3/breadcrumb/policy_default"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="wcm/core/components/policies/mapping"/>
             </container>
             <experiencefragment_h
-                cq:policy="core/wcm/components/experiencefragment/v1/experiencefragment/policy_header"
+                cq:policy="core/wcm/components/experiencefragment/v2/experiencefragment/policy_header"
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="wcm/core/components/policies/mapping"/>
             <experiencefragment
-                cq:policy="core/wcm/components/experiencefragment/v1/experiencefragment/policy_footer"
+                cq:policy="core/wcm/components/experiencefragment/v2/experiencefragment/policy_footer"
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="wcm/core/components/policies/mapping"/>
         </root>

--- a/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/article-page/structure/.content.xml
+++ b/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/article-page/structure/.content.xml
@@ -5,14 +5,14 @@
         cq:deviceGroups="[mobile/groups/responsive]"
         cq:template="/conf/aem-site-template-standard/settings/wcm/templates/article-page"
         jcr:primaryType="cq:PageContent"
-        sling:resourceType="core/wcm/components/page/v2/page">
+        sling:resourceType="core/wcm/components/page/v3/page">
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="core/wcm/components/container/v1/container"
             layout="simple">
             <experiencefragment_h
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="core/wcm/components/experiencefragment/v1/experiencefragment"
+                sling:resourceType="core/wcm/components/experiencefragment/v2/experiencefragment"
                 fragmentVariationPath="/content/experience-fragments/aem-site-template-standard/en/site/header/master"/>
             <container
                 jcr:primaryType="nt:unstructured"
@@ -21,7 +21,7 @@
                 <breadcrumb
                     cq:styleIds="[1612951394793]"
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="core/wcm/components/breadcrumb/v2/breadcrumb">
+                    sling:resourceType="core/wcm/components/breadcrumb/v3/breadcrumb">
                     <cq:responsive jcr:primaryType="nt:unstructured">
                         <default
                             jcr:primaryType="nt:unstructured"
@@ -36,7 +36,7 @@
                 <title
                     cq:styleIds="[1612984301150]"
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="core/wcm/components/title/v2/title">
+                    sling:resourceType="core/wcm/components/title/v3/title">
                     <cq:responsive jcr:primaryType="nt:unstructured">
                         <default
                             jcr:primaryType="nt:unstructured"
@@ -65,7 +65,7 @@
             </container>
             <experiencefragment
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="core/wcm/components/experiencefragment/v1/experiencefragment"
+                sling:resourceType="core/wcm/components/experiencefragment/v2/experiencefragment"
                 fragmentVariationPath="/content/experience-fragments/aem-site-template-standard/en/site/footer/master"/>
         </root>
         <cq:responsive jcr:primaryType="nt:unstructured">

--- a/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/contact-us/initial/.content.xml
+++ b/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/contact-us/initial/.content.xml
@@ -4,7 +4,7 @@
     <jcr:content
         cq:template="/conf/aem-site-template-standard/settings/wcm/templates/contact-us"
         jcr:primaryType="cq:PageContent"
-        sling:resourceType="core/wcm/components/page/v2/page">
+        sling:resourceType="core/wcm/components/page/v3/page">
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="core/wcm/components/container/v1/container">

--- a/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/contact-us/policies/.content.xml
+++ b/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/contact-us/policies/.content.xml
@@ -2,7 +2,7 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:primaryType="cq:Page">
     <jcr:content
-        cq:policy="core/wcm/components/page/v2/page/policy_contact_us"
+        cq:policy="core/wcm/components/page/v3/page/policy_contact_us"
         jcr:primaryType="nt:unstructured"
         sling:resourceType="wcm/core/components/policies/mappings">
         <root
@@ -22,12 +22,12 @@
                             <wcm jcr:primaryType="nt:unstructured">
                                 <components jcr:primaryType="nt:unstructured">
                                     <title jcr:primaryType="nt:unstructured">
-                                        <v2 jcr:primaryType="nt:unstructured">
+                                        <v3 jcr:primaryType="nt:unstructured">
                                             <title
-                                                cq:policy="core/wcm/components/title/v2/title/policy_default"
+                                                cq:policy="core/wcm/components/title/v3/title/policy_default"
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="wcm/core/components/policies/mapping"/>
-                                        </v2>
+                                        </v3>
                                     </title>
                                     <text jcr:primaryType="nt:unstructured">
                                         <v2 jcr:primaryType="nt:unstructured">
@@ -38,12 +38,12 @@
                                         </v2>
                                     </text>
                                     <teaser jcr:primaryType="nt:unstructured">
-                                        <v1 jcr:primaryType="nt:unstructured">
+                                        <v2 jcr:primaryType="nt:unstructured">
                                             <teaser
-                                                cq:policy="core/wcm/components/teaser/v1/teaser/policy_default"
+                                                cq:policy="core/wcm/components/teaser/v2/teaser/policy_default"
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="wcm/core/components/policies/mapping"/>
-                                        </v1>
+                                        </v2>
                                     </teaser>
                                     <separator jcr:primaryType="nt:unstructured">
                                         <v1 jcr:primaryType="nt:unstructured">
@@ -54,12 +54,12 @@
                                         </v1>
                                     </separator>
                                     <image jcr:primaryType="nt:unstructured">
-                                        <v2 jcr:primaryType="nt:unstructured">
+                                        <v3 jcr:primaryType="nt:unstructured">
                                             <image
-                                                cq:policy="core/wcm/components/image/v2/image/policy_default"
+                                                cq:policy="core/wcm/components/image/v3/image/policy_default"
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="wcm/core/components/policies/mapping"/>
-                                        </v2>
+                                        </v3>
                                     </image>
                                     <container jcr:primaryType="nt:unstructured">
                                         <v1 jcr:primaryType="nt:unstructured">
@@ -81,12 +81,12 @@
                             <wcm jcr:primaryType="nt:unstructured">
                                 <components jcr:primaryType="nt:unstructured">
                                     <title jcr:primaryType="nt:unstructured">
-                                        <v2 jcr:primaryType="nt:unstructured">
+                                        <v3 jcr:primaryType="nt:unstructured">
                                             <title
-                                                cq:policy="core/wcm/components/title/v2/title/policy_default"
+                                                cq:policy="core/wcm/components/title/v3/title/policy_default"
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="wcm/core/components/policies/mapping"/>
-                                        </v2>
+                                        </v3>
                                     </title>
                                     <text jcr:primaryType="nt:unstructured">
                                         <v2 jcr:primaryType="nt:unstructured">
@@ -97,12 +97,12 @@
                                         </v2>
                                     </text>
                                     <teaser jcr:primaryType="nt:unstructured">
-                                        <v1 jcr:primaryType="nt:unstructured">
+                                        <v2 jcr:primaryType="nt:unstructured">
                                             <teaser
-                                                cq:policy="core/wcm/components/teaser/v1/teaser/policy_default"
+                                                cq:policy="core/wcm/components/teaser/v2/teaser/policy_default"
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="wcm/core/components/policies/mapping"/>
-                                        </v1>
+                                        </v2>
                                     </teaser>
                                     <separator jcr:primaryType="nt:unstructured">
                                         <v1 jcr:primaryType="nt:unstructured">
@@ -113,19 +113,19 @@
                                         </v1>
                                     </separator>
                                     <image jcr:primaryType="nt:unstructured">
-                                        <v2 jcr:primaryType="nt:unstructured">
+                                        <v3 jcr:primaryType="nt:unstructured">
                                             <image
-                                                cq:policy="core/wcm/components/image/v2/image/policy_default"
+                                                cq:policy="core/wcm/components/image/v3/image/policy_default"
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="wcm/core/components/policies/mapping"/>
-                                        </v2>
+                                        </v3>
                                     </image>
                                 </components>
                             </wcm>
                         </core>
                     </container_1748665491>
                     <title
-                        cq:policy="core/wcm/components/title/v2/title/policy_page"
+                        cq:policy="core/wcm/components/title/v3/title/policy_page"
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="wcm/core/components/policies/mapping"/>
                     <container_820040118
@@ -136,12 +136,12 @@
                             <wcm jcr:primaryType="nt:unstructured">
                                 <components jcr:primaryType="nt:unstructured">
                                     <title jcr:primaryType="nt:unstructured">
-                                        <v2 jcr:primaryType="nt:unstructured">
+                                        <v3 jcr:primaryType="nt:unstructured">
                                             <title
-                                                cq:policy="core/wcm/components/title/v2/title/policy_default"
+                                                cq:policy="core/wcm/components/title/v3/title/policy_default"
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="wcm/core/components/policies/mapping"/>
-                                        </v2>
+                                        </v3>
                                     </title>
                                     <text jcr:primaryType="nt:unstructured">
                                         <v2 jcr:primaryType="nt:unstructured">
@@ -152,12 +152,12 @@
                                         </v2>
                                     </text>
                                     <teaser jcr:primaryType="nt:unstructured">
-                                        <v1 jcr:primaryType="nt:unstructured">
+                                        <v2 jcr:primaryType="nt:unstructured">
                                             <teaser
-                                                cq:policy="core/wcm/components/teaser/v1/teaser/policy_default"
+                                                cq:policy="core/wcm/components/teaser/v2/teaser/policy_default"
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="wcm/core/components/policies/mapping"/>
-                                        </v1>
+                                        </v2>
                                     </teaser>
                                     <separator jcr:primaryType="nt:unstructured">
                                         <v1 jcr:primaryType="nt:unstructured">
@@ -168,20 +168,20 @@
                                         </v1>
                                     </separator>
                                     <image jcr:primaryType="nt:unstructured">
-                                        <v2 jcr:primaryType="nt:unstructured">
+                                        <v3 jcr:primaryType="nt:unstructured">
                                             <image
-                                                cq:policy="core/wcm/components/image/v2/image/policy_default"
+                                                cq:policy="core/wcm/components/image/v3/image/policy_default"
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="wcm/core/components/policies/mapping"/>
-                                        </v2>
+                                        </v3>
                                     </image>
                                     <breadcrumb jcr:primaryType="nt:unstructured">
-                                        <v2 jcr:primaryType="nt:unstructured">
+                                        <v3 jcr:primaryType="nt:unstructured">
                                             <breadcrumb
-                                                cq:policy="core/wcm/components/breadcrumb/v2/breadcrumb/policy_default"
+                                                cq:policy="core/wcm/components/breadcrumb/v3/breadcrumb/policy_default"
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="wcm/core/components/policies/mapping"/>
-                                        </v2>
+                                        </v3>
                                     </breadcrumb>
                                     <tabs jcr:primaryType="nt:unstructured">
                                         <v1 jcr:primaryType="nt:unstructured">
@@ -200,12 +200,12 @@
                                         </v1>
                                     </container>
                                     <button jcr:primaryType="nt:unstructured">
-                                        <v1 jcr:primaryType="nt:unstructured">
+                                        <v2 jcr:primaryType="nt:unstructured">
                                             <button
-                                                cq:policy="core/wcm/components/button/v1/button/policy_default"
+                                                cq:policy="core/wcm/components/button/v2/button/policy_default"
                                                 jcr:primaryType="nt:unstructured"
                                                 sling:resourceType="wcm/core/components/policies/mapping"/>
-                                        </v1>
+                                        </v2>
                                     </button>
                                 </components>
                             </wcm>
@@ -213,11 +213,11 @@
                     </container_820040118>
                 </container>
                 <title
-                    cq:policy="core/wcm/components/title/v2/title/policy_page"
+                    cq:policy="core/wcm/components/title/v3/title/policy_page"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="wcm/core/components/policies/mapping"/>
                 <breadcrumb
-                    cq:policy="core/wcm/components/breadcrumb/v2/breadcrumb/policy_default"
+                    cq:policy="core/wcm/components/breadcrumb/v3/breadcrumb/policy_default"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="wcm/core/components/policies/mapping"/>
                 <container_820040118
@@ -228,12 +228,12 @@
                         <wcm jcr:primaryType="nt:unstructured">
                             <components jcr:primaryType="nt:unstructured">
                                 <title jcr:primaryType="nt:unstructured">
-                                    <v2 jcr:primaryType="nt:unstructured">
+                                    <v3 jcr:primaryType="nt:unstructured">
                                         <title
-                                            cq:policy="core/wcm/components/title/v2/title/policy_default"
+                                            cq:policy="core/wcm/components/title/v3/title/policy_default"
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="wcm/core/components/policies/mapping"/>
-                                    </v2>
+                                    </v3>
                                 </title>
                                 <text jcr:primaryType="nt:unstructured">
                                     <v2 jcr:primaryType="nt:unstructured">
@@ -244,20 +244,20 @@
                                     </v2>
                                 </text>
                                 <teaser jcr:primaryType="nt:unstructured">
-                                    <v1 jcr:primaryType="nt:unstructured">
-                                        <teaser
-                                            cq:policy="core/wcm/components/teaser/v1/teaser/policy_default"
-                                            jcr:primaryType="nt:unstructured"
-                                            sling:resourceType="wcm/core/components/policies/mapping"/>
-                                    </v1>
-                                </teaser>
-                                <breadcrumb jcr:primaryType="nt:unstructured">
                                     <v2 jcr:primaryType="nt:unstructured">
-                                        <breadcrumb
-                                            cq:policy="core/wcm/components/breadcrumb/v2/breadcrumb/policy_default"
+                                        <teaser
+                                            cq:policy="core/wcm/components/teaser/v2/teaser/policy_default"
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="wcm/core/components/policies/mapping"/>
                                     </v2>
+                                </teaser>
+                                <breadcrumb jcr:primaryType="nt:unstructured">
+                                    <v3 jcr:primaryType="nt:unstructured">
+                                        <breadcrumb
+                                            cq:policy="core/wcm/components/breadcrumb/v3/breadcrumb/policy_default"
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="wcm/core/components/policies/mapping"/>
+                                    </v3>
                                 </breadcrumb>
                                 <separator jcr:primaryType="nt:unstructured">
                                     <v1 jcr:primaryType="nt:unstructured">
@@ -279,20 +279,20 @@
                         <wcm jcr:primaryType="nt:unstructured">
                             <components jcr:primaryType="nt:unstructured">
                                 <breadcrumb jcr:primaryType="nt:unstructured">
-                                    <v2 jcr:primaryType="nt:unstructured">
+                                    <v3 jcr:primaryType="nt:unstructured">
                                         <breadcrumb
-                                            cq:policy="core/wcm/components/breadcrumb/v2/breadcrumb/policy_default"
+                                            cq:policy="core/wcm/components/breadcrumb/v3/breadcrumb/policy_default"
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="wcm/core/components/policies/mapping"/>
-                                    </v2>
+                                    </v3>
                                 </breadcrumb>
                                 <image jcr:primaryType="nt:unstructured">
-                                    <v2 jcr:primaryType="nt:unstructured">
+                                    <v3 jcr:primaryType="nt:unstructured">
                                         <image
-                                            cq:policy="core/wcm/components/image/v2/image/policy_default"
+                                            cq:policy="core/wcm/components/image/v3/image/policy_default"
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="wcm/core/components/policies/mapping"/>
-                                    </v2>
+                                    </v3>
                                 </image>
                                 <separator jcr:primaryType="nt:unstructured">
                                     <v1 jcr:primaryType="nt:unstructured">
@@ -303,12 +303,12 @@
                                     </v1>
                                 </separator>
                                 <teaser jcr:primaryType="nt:unstructured">
-                                    <v1 jcr:primaryType="nt:unstructured">
+                                    <v2 jcr:primaryType="nt:unstructured">
                                         <teaser
-                                            cq:policy="core/wcm/components/teaser/v1/teaser/policy_default"
+                                            cq:policy="core/wcm/components/teaser/v2/teaser/policy_default"
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="wcm/core/components/policies/mapping"/>
-                                    </v1>
+                                    </v2>
                                 </teaser>
                                 <text jcr:primaryType="nt:unstructured">
                                     <v2 jcr:primaryType="nt:unstructured">
@@ -319,12 +319,12 @@
                                     </v2>
                                 </text>
                                 <title jcr:primaryType="nt:unstructured">
-                                    <v2 jcr:primaryType="nt:unstructured">
+                                    <v3 jcr:primaryType="nt:unstructured">
                                         <title
-                                            cq:policy="core/wcm/components/title/v2/title/policy_default"
+                                            cq:policy="core/wcm/components/title/v3/title/policy_default"
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="wcm/core/components/policies/mapping"/>
-                                    </v2>
+                                    </v3>
                                 </title>
                                 <tabs jcr:primaryType="nt:unstructured">
                                     <v1 jcr:primaryType="nt:unstructured">
@@ -343,12 +343,12 @@
                                     </v1>
                                 </container>
                                 <button jcr:primaryType="nt:unstructured">
-                                    <v1 jcr:primaryType="nt:unstructured">
+                                    <v2 jcr:primaryType="nt:unstructured">
                                         <button
-                                            cq:policy="core/wcm/components/button/v1/button/policy_default"
+                                            cq:policy="core/wcm/components/button/v2/button/policy_default"
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="wcm/core/components/policies/mapping"/>
-                                    </v1>
+                                    </v2>
                                 </button>
                             </components>
                         </wcm>
@@ -356,11 +356,11 @@
                 </container_1748665491>
             </container>
             <experiencefragment_h
-                cq:policy="core/wcm/components/experiencefragment/v1/experiencefragment/policy_header"
+                cq:policy="core/wcm/components/experiencefragment/v2/experiencefragment/policy_header"
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="wcm/core/components/policies/mapping"/>
             <experiencefragment_f
-                cq:policy="core/wcm/components/experiencefragment/v1/experiencefragment/policy_footer"
+                cq:policy="core/wcm/components/experiencefragment/v2/experiencefragment/policy_footer"
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="wcm/core/components/policies/mapping"/>
         </root>

--- a/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/contact-us/structure/.content.xml
+++ b/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/contact-us/structure/.content.xml
@@ -5,14 +5,14 @@
         cq:deviceGroups="[mobile/groups/responsive]"
         cq:template="/conf/aem-site-template-standard/settings/wcm/templates/contact-us"
         jcr:primaryType="cq:PageContent"
-        sling:resourceType="core/wcm/components/page/v2/page">
+        sling:resourceType="core/wcm/components/page/v3/page">
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="core/wcm/components/container/v1/container"
             layout="simple">
             <experiencefragment_h
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="core/wcm/components/experiencefragment/v1/experiencefragment"
+                sling:resourceType="core/wcm/components/experiencefragment/v2/experiencefragment"
                 fragmentVariationPath="/content/experience-fragments/aem-site-template-standard/en/site/header/master"/>
             <container
                 jcr:primaryType="nt:unstructured"
@@ -21,7 +21,7 @@
                 <breadcrumb
                     cq:styleIds="[1612951394793]"
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="core/wcm/components/breadcrumb/v2/breadcrumb">
+                    sling:resourceType="core/wcm/components/breadcrumb/v3/breadcrumb">
                     <cq:responsive jcr:primaryType="nt:unstructured">
                         <default
                             jcr:primaryType="nt:unstructured"
@@ -52,7 +52,7 @@
                         cq:styleIds="[1612984301150]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Contact us"
-                        sling:resourceType="core/wcm/components/title/v2/title">
+                        sling:resourceType="core/wcm/components/title/v3/title">
                         <cq:responsive jcr:primaryType="nt:unstructured">
                             <default
                                 jcr:primaryType="nt:unstructured"
@@ -83,7 +83,7 @@
             </container>
             <experiencefragment_f
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="core/wcm/components/experiencefragment/v1/experiencefragment"
+                sling:resourceType="core/wcm/components/experiencefragment/v2/experiencefragment"
                 fragmentVariationPath="/content/experience-fragments/aem-site-template-standard/en/site/footer/master"/>
         </root>
         <cq:responsive jcr:primaryType="nt:unstructured">

--- a/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/content-page/initial/.content.xml
+++ b/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/content-page/initial/.content.xml
@@ -4,7 +4,7 @@
     <jcr:content
         cq:template="/conf/aem-site-template-standard/settings/wcm/templates/article-page"
         jcr:primaryType="cq:PageContent"
-        sling:resourceType="core/wcm/components/page/v2/page">
+        sling:resourceType="core/wcm/components/page/v3/page">
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="core/wcm/components/container/v1/container">

--- a/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/content-page/policies/.content.xml
+++ b/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/content-page/policies/.content.xml
@@ -2,7 +2,7 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:primaryType="cq:Page">
     <jcr:content
-        cq:policy="core/wcm/components/page/v2/page/policy_default"
+        cq:policy="core/wcm/components/page/v3/page/policy_default"
         jcr:primaryType="nt:unstructured"
         sling:resourceType="wcm/core/components/policies/mappings">
         <root

--- a/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/content-page/structure/.content.xml
+++ b/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/content-page/structure/.content.xml
@@ -5,14 +5,14 @@
         cq:deviceGroups="[mobile/groups/responsive]"
         cq:template="/conf/aem-site-template-standard/settings/wcm/templates/article-page"
         jcr:primaryType="cq:PageContent"
-        sling:resourceType="core/wcm/components/page/v2/page">
+        sling:resourceType="core/wcm/components/page/v3/page">
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="core/wcm/components/container/v1/container"
             layout="simple">
             <experiencefragment_h
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="core/wcm/components/experiencefragment/v1/experiencefragment"
+                sling:resourceType="core/wcm/components/experiencefragment/v2/experiencefragment"
                 fragmentVariationPath="/content/experience-fragments/aem-site-template-standard/en/site/header/master"/>
             <container
                 jcr:primaryType="nt:unstructured"
@@ -20,10 +20,10 @@
                 layout="responsiveGrid">
                 <breadcrumb
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="core/wcm/components/breadcrumb/v2/breadcrumb"/>
+                    sling:resourceType="core/wcm/components/breadcrumb/v3/breadcrumb"/>
                 <title
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="core/wcm/components/title/v2/title">
+                    sling:resourceType="core/wcm/components/title/v3/title">
                     <cq:responsive jcr:primaryType="nt:unstructured">
                         <default
                             jcr:primaryType="nt:unstructured"
@@ -51,7 +51,7 @@
             </container>
             <experiencefragment_f
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="core/wcm/components/experiencefragment/v1/experiencefragment"
+                sling:resourceType="core/wcm/components/experiencefragment/v2/experiencefragment"
                 fragmentVariationPath="/content/experience-fragments/aem-site-template-standard/en/site/footer/master">
                 <cq:responsive jcr:primaryType="nt:unstructured">
                     <default

--- a/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/home-page/initial/.content.xml
+++ b/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/home-page/initial/.content.xml
@@ -4,7 +4,7 @@
     <jcr:content
         cq:template="/conf/aem-site-template-standard/settings/wcm/templates/home-page"
         jcr:primaryType="cq:PageContent"
-        sling:resourceType="core/wcm/components/page/v2/page">
+        sling:resourceType="core/wcm/components/page/v3/page">
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="core/wcm/components/container/v1/container">
@@ -20,7 +20,7 @@
                     layout="responsiveGrid">
                     <teaser
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"/>
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"/>
                 </container>
             </container>
         </root>

--- a/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/home-page/policies/.content.xml
+++ b/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/home-page/policies/.content.xml
@@ -2,7 +2,7 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:primaryType="cq:Page">
     <jcr:content
-        cq:policy="core/wcm/components/page/v2/page/policy_home"
+        cq:policy="core/wcm/components/page/v3/page/policy_home"
         jcr:primaryType="nt:unstructured"
         sling:resourceType="wcm/core/components/policies/mappings">
         <root
@@ -10,7 +10,7 @@
             jcr:primaryType="nt:unstructured"
             sling:resourceType="wcm/core/components/policies/mappings">
             <experiencefragment-header
-                cq:policy="core/wcm/components/experiencefragment/v1/experiencefragment/policy_header"
+                cq:policy="core/wcm/components/experiencefragment/v2/experiencefragment/policy_header"
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="wcm/core/components/policies/mappings"/>
             <container
@@ -18,7 +18,7 @@
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="wcm/core/components/policies/mappings">
                 <title
-                    cq:policy="core/wcm/components/title/v2/title/policy_page"
+                    cq:policy="core/wcm/components/title/v3/title/policy_page"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="wcm/core/components/policies/mapping"/>
                 <container
@@ -29,20 +29,20 @@
                         <wcm jcr:primaryType="nt:unstructured">
                             <components jcr:primaryType="nt:unstructured">
                                 <download jcr:primaryType="nt:unstructured">
-                                    <v1 jcr:primaryType="nt:unstructured">
+                                    <v2 jcr:primaryType="nt:unstructured">
                                         <download
-                                            cq:policy="core/wcm/components/download/v1/download/policy_default"
+                                            cq:policy="core/wcm/components/download/v2/download/policy_default"
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="wcm/core/components/policies/mappings"/>
-                                    </v1>
+                                    </v2>
                                 </download>
                                 <teaser jcr:primaryType="nt:unstructured">
-                                    <v1 jcr:primaryType="nt:unstructured">
+                                    <v2 jcr:primaryType="nt:unstructured">
                                         <teaser
-                                            cq:policy="core/wcm/components/teaser/v1/teaser/policy_default"
+                                            cq:policy="core/wcm/components/teaser/v2/teaser/policy_default"
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="wcm/core/components/policies/mappings"/>
-                                    </v1>
+                                    </v2>
                                 </teaser>
                                 <container jcr:primaryType="nt:unstructured">
                                     <v1 jcr:primaryType="nt:unstructured">
@@ -53,12 +53,12 @@
                                     </v1>
                                 </container>
                                 <title jcr:primaryType="nt:unstructured">
-                                    <v2 jcr:primaryType="nt:unstructured">
+                                    <v3 jcr:primaryType="nt:unstructured">
                                         <title
-                                            cq:policy="core/wcm/components/title/v2/title/policy_default"
+                                            cq:policy="core/wcm/components/title/v3/title/policy_default"
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="wcm/core/components/policies/mappings"/>
-                                    </v2>
+                                    </v3>
                                 </title>
                                 <text jcr:primaryType="nt:unstructured">
                                     <v2 jcr:primaryType="nt:unstructured">
@@ -69,12 +69,12 @@
                                     </v2>
                                 </text>
                                 <image jcr:primaryType="nt:unstructured">
-                                    <v2 jcr:primaryType="nt:unstructured">
+                                    <v3 jcr:primaryType="nt:unstructured">
                                         <image
-                                            cq:policy="core/wcm/components/image/v2/image/policy_default"
+                                            cq:policy="core/wcm/components/image/v3/image/policy_default"
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="wcm/core/components/policies/mappings"/>
-                                    </v2>
+                                    </v3>
                                 </image>
                                 <form jcr:primaryType="nt:unstructured">
                                     <container jcr:primaryType="nt:unstructured">
@@ -90,7 +90,7 @@
                         </wcm>
                     </core>
                     <teaser
-                        cq:policy="core/wcm/components/teaser/v1/teaser/policy_default"
+                        cq:policy="core/wcm/components/teaser/v2/teaser/policy_default"
                         jcr:primaryType="nt:unstructured"
                         sling:resourceType="wcm/core/components/policies/mapping"/>
                 </container>
@@ -102,20 +102,20 @@
                         <wcm jcr:primaryType="nt:unstructured">
                             <components jcr:primaryType="nt:unstructured">
                                 <teaser jcr:primaryType="nt:unstructured">
-                                    <v1 jcr:primaryType="nt:unstructured">
-                                        <teaser
-                                            cq:policy="core/wcm/components/teaser/v1/teaser/policy_default"
-                                            jcr:primaryType="nt:unstructured"
-                                            sling:resourceType="wcm/core/components/policies/mapping"/>
-                                    </v1>
-                                </teaser>
-                                <title jcr:primaryType="nt:unstructured">
                                     <v2 jcr:primaryType="nt:unstructured">
-                                        <title
-                                            cq:policy="core/wcm/components/title/v2/title/policy_default"
+                                        <teaser
+                                            cq:policy="core/wcm/components/teaser/v2/teaser/policy_default"
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="wcm/core/components/policies/mapping"/>
                                     </v2>
+                                </teaser>
+                                <title jcr:primaryType="nt:unstructured">
+                                    <v3 jcr:primaryType="nt:unstructured">
+                                        <title
+                                            cq:policy="core/wcm/components/title/v3/title/policy_default"
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="wcm/core/components/policies/mapping"/>
+                                    </v3>
                                 </title>
                                 <text jcr:primaryType="nt:unstructured">
                                     <v2 jcr:primaryType="nt:unstructured">
@@ -134,28 +134,28 @@
                                     </v1>
                                 </separator>
                                 <image jcr:primaryType="nt:unstructured">
-                                    <v2 jcr:primaryType="nt:unstructured">
+                                    <v3 jcr:primaryType="nt:unstructured">
                                         <image
-                                            cq:policy="core/wcm/components/image/v2/image/policy_default"
+                                            cq:policy="core/wcm/components/image/v3/image/policy_default"
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="wcm/core/components/policies/mapping"/>
-                                    </v2>
+                                    </v3>
                                 </image>
                                 <breadcrumb jcr:primaryType="nt:unstructured">
-                                    <v2 jcr:primaryType="nt:unstructured">
+                                    <v3 jcr:primaryType="nt:unstructured">
                                         <breadcrumb
-                                            cq:policy="core/wcm/components/breadcrumb/v2/breadcrumb/policy_default"
+                                            cq:policy="core/wcm/components/breadcrumb/v3/breadcrumb/policy_default"
+                                            jcr:primaryType="nt:unstructured"
+                                            sling:resourceType="wcm/core/components/policies/mapping"/>
+                                    </v3>
+                                </breadcrumb>
+                                <button jcr:primaryType="nt:unstructured">
+                                    <v2 jcr:primaryType="nt:unstructured">
+                                        <button
+                                            cq:policy="core/wcm/components/button/v2/button/policy_default"
                                             jcr:primaryType="nt:unstructured"
                                             sling:resourceType="wcm/core/components/policies/mapping"/>
                                     </v2>
-                                </breadcrumb>
-                                <button jcr:primaryType="nt:unstructured">
-                                    <v1 jcr:primaryType="nt:unstructured">
-                                        <button
-                                            cq:policy="core/wcm/components/button/v1/button/policy_default"
-                                            jcr:primaryType="nt:unstructured"
-                                            sling:resourceType="wcm/core/components/policies/mapping"/>
-                                    </v1>
                                 </button>
                                 <container jcr:primaryType="nt:unstructured">
                                     <v1 jcr:primaryType="nt:unstructured">
@@ -179,7 +179,7 @@
                 </container_1578756628>
             </container>
             <experiencefragment-footer
-                cq:policy="core/wcm/components/experiencefragment/v1/experiencefragment/policy_footer"
+                cq:policy="core/wcm/components/experiencefragment/v2/experiencefragment/policy_footer"
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="wcm/core/components/policies/mappings"/>
         </root>

--- a/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/home-page/structure/.content.xml
+++ b/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/home-page/structure/.content.xml
@@ -5,14 +5,14 @@
         cq:deviceGroups="[mobile/groups/responsive]"
         cq:template="/conf/aem-site-template-standard/settings/wcm/templates/home-page"
         jcr:primaryType="cq:PageContent"
-        sling:resourceType="core/wcm/components/page/v2/page">
+        sling:resourceType="core/wcm/components/page/v3/page">
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="core/wcm/components/container/v1/container"
             layout="simple">
             <experiencefragment-header
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="core/wcm/components/experiencefragment/v1/experiencefragment"
+                sling:resourceType="core/wcm/components/experiencefragment/v2/experiencefragment"
                 fragmentVariationPath="/content/experience-fragments/aem-site-template-standard/en/site/header/master">
                 <cq:responsive jcr:primaryType="nt:unstructured">
                     <default
@@ -31,7 +31,7 @@
                     layout="responsiveGrid">
                     <teaser
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         editable="{Boolean}true"/>
                 </container>
                 <container_1578756628
@@ -49,7 +49,7 @@
             </container>
             <experiencefragment-footer
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="core/wcm/components/experiencefragment/v1/experiencefragment"
+                sling:resourceType="core/wcm/components/experiencefragment/v2/experiencefragment"
                 fragmentVariationPath="/content/experience-fragments/aem-site-template-standard/en/site/footer/master"/>
         </root>
         <cq:responsive jcr:primaryType="nt:unstructured">

--- a/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/xf-web-variation/policies/.content.xml
+++ b/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/xf-web-variation/policies/.content.xml
@@ -13,20 +13,20 @@
                 <wcm jcr:primaryType="nt:unstructured">
                     <components jcr:primaryType="nt:unstructured">
                         <download jcr:primaryType="nt:unstructured">
-                            <v1 jcr:primaryType="nt:unstructured">
+                            <v2 jcr:primaryType="nt:unstructured">
                                 <download
-                                    cq:policy="core/wcm/components/download/v1/download/policy_default"
+                                    cq:policy="core/wcm/components/download/v2/download/policy_default"
                                     jcr:primaryType="nt:unstructured"
                                     sling:resourceType="wcm/core/components/policies/mappings"/>
-                            </v1>
+                            </v2>
                         </download>
                         <teaser jcr:primaryType="nt:unstructured">
-                            <v1 jcr:primaryType="nt:unstructured">
+                            <v2 jcr:primaryType="nt:unstructured">
                                 <teaser
-                                    cq:policy="core/wcm/components/teaser/v1/teaser/policy_default"
+                                    cq:policy="core/wcm/components/teaser/v2/teaser/policy_default"
                                     jcr:primaryType="nt:unstructured"
                                     sling:resourceType="wcm/core/components/policies/mappings"/>
-                            </v1>
+                            </v2>
                         </teaser>
                         <container jcr:primaryType="nt:unstructured">
                             <v1 jcr:primaryType="nt:unstructured">
@@ -37,12 +37,12 @@
                             </v1>
                         </container>
                         <title jcr:primaryType="nt:unstructured">
-                            <v2 jcr:primaryType="nt:unstructured">
+                            <v3 jcr:primaryType="nt:unstructured">
                                 <title
-                                    cq:policy="core/wcm/components/title/v2/title/policy_default"
+                                    cq:policy="core/wcm/components/title/v3/title/policy_default"
                                     jcr:primaryType="nt:unstructured"
                                     sling:resourceType="wcm/core/components/policies/mapping"/>
-                            </v2>
+                            </v3>
                         </title>
                         <text jcr:primaryType="nt:unstructured">
                             <v2 jcr:primaryType="nt:unstructured">
@@ -53,12 +53,12 @@
                             </v2>
                         </text>
                         <image jcr:primaryType="nt:unstructured">
-                            <v2 jcr:primaryType="nt:unstructured">
+                            <v3 jcr:primaryType="nt:unstructured">
                                 <image
-                                    cq:policy="core/wcm/components/image/v2/image/policy_default"
+                                    cq:policy="core/wcm/components/image/v3/image/policy_default"
                                     jcr:primaryType="nt:unstructured"
                                     sling:resourceType="wcm/core/components/policies/mappings"/>
-                            </v2>
+                            </v3>
                         </image>
                         <form jcr:primaryType="nt:unstructured">
                             <container jcr:primaryType="nt:unstructured">

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/.content.xml
@@ -11,7 +11,7 @@
         sling:configRef="/conf/aem-site-template-standard"
         sling:redirect="{Boolean}true"
         sling:redirectStatus="{Long}302"
-        sling:resourceType="core/wcm/components/page/v2/page">
+        sling:resourceType="core/wcm/components/page/v3/page">
         <image jcr:primaryType="nt:unstructured">
             <file/>
         </image>

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/de/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/de/.content.xml
@@ -12,7 +12,7 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="German"
-        sling:resourceType="core/wcm/components/page/v2/page"
+        sling:resourceType="core/wcm/components/page/v3/page"
         facebookAppId="123456"
         pageTitle="My Site"
         socialMedia="[facebook,pinterest]">
@@ -25,7 +25,7 @@
                 sling:resourceType="core/wcm/components/container/v1/container">
                 <title
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="core/wcm/components/title/v2/title"/>
+                    sling:resourceType="core/wcm/components/title/v3/title"/>
                 <container
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="core/wcm/components/container/v1/container"
@@ -34,7 +34,7 @@
                         jcr:description="&lt;p>Don't stop half way, go for the top!&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Epic Journey"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="false"
                         descriptionFromPage="false"
                         textIsRich="true"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/de/article/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/de/article/.content.xml
@@ -8,7 +8,7 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Article"
-        sling:resourceType="core/wcm/components/page/v2/page"
+        sling:resourceType="core/wcm/components/page/v3/page"
         socialMedia="[facebook,pinterest]">
         <root
             jcr:primaryType="nt:unstructured"
@@ -35,7 +35,7 @@
                         cq:styleIds="[1612913724665]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Symphony in Steel by Tobias Keller"
-                        sling:resourceType="core/wcm/components/image/v2/image"
+                        sling:resourceType="core/wcm/components/image/v3/image"
                         displayPopupTitle="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
                         isDecorative="true"
@@ -51,7 +51,7 @@
                         cq:styleIds="[1612896641947]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Subtitle"
-                        sling:resourceType="core/wcm/components/title/v2/title"
+                        sling:resourceType="core/wcm/components/title/v3/title"
                         type="h2">
                         <cq:responsive jcr:primaryType="nt:unstructured">
                             <default
@@ -92,7 +92,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
@@ -121,7 +121,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/de/article/sample-article-1/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/de/article/sample-article-1/.content.xml
@@ -8,7 +8,7 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Sample Article 1"
-        sling:resourceType="core/wcm/components/page/v2/page"
+        sling:resourceType="core/wcm/components/page/v3/page"
         socialMedia="[facebook,pinterest]">
         <root
             jcr:primaryType="nt:unstructured"
@@ -35,7 +35,7 @@
                         cq:styleIds="[1612913724665]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Symphony in Steel by Tobias Keller"
-                        sling:resourceType="core/wcm/components/image/v2/image"
+                        sling:resourceType="core/wcm/components/image/v3/image"
                         displayPopupTitle="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
                         isDecorative="true"
@@ -51,7 +51,7 @@
                         cq:styleIds="[1612896641947]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Subtitle"
-                        sling:resourceType="core/wcm/components/title/v2/title"
+                        sling:resourceType="core/wcm/components/title/v3/title"
                         type="h2">
                         <cq:responsive jcr:primaryType="nt:unstructured">
                             <default
@@ -92,7 +92,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
@@ -121,7 +121,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/de/article/sample-article-2/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/de/article/sample-article-2/.content.xml
@@ -8,7 +8,7 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Sample Article 2"
-        sling:resourceType="core/wcm/components/page/v2/page"
+        sling:resourceType="core/wcm/components/page/v3/page"
         socialMedia="[facebook,pinterest]">
         <root
             jcr:primaryType="nt:unstructured"
@@ -35,7 +35,7 @@
                         cq:styleIds="[1612913724665]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Symphony in Steel by Tobias Keller"
-                        sling:resourceType="core/wcm/components/image/v2/image"
+                        sling:resourceType="core/wcm/components/image/v3/image"
                         displayPopupTitle="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
                         isDecorative="true"
@@ -51,7 +51,7 @@
                         cq:styleIds="[1612896641947]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Subtitle"
-                        sling:resourceType="core/wcm/components/title/v2/title"
+                        sling:resourceType="core/wcm/components/title/v3/title"
                         type="h2">
                         <cq:responsive jcr:primaryType="nt:unstructured">
                             <default
@@ -92,7 +92,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
@@ -121,7 +121,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/de/article/sample-article-3/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/de/article/sample-article-3/.content.xml
@@ -8,7 +8,7 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Sample Article 3"
-        sling:resourceType="core/wcm/components/page/v2/page"
+        sling:resourceType="core/wcm/components/page/v3/page"
         socialMedia="[facebook,pinterest]">
         <root
             jcr:primaryType="nt:unstructured"
@@ -35,7 +35,7 @@
                         cq:styleIds="[1612913724665]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Symphony in Steel by Tobias Keller"
-                        sling:resourceType="core/wcm/components/image/v2/image"
+                        sling:resourceType="core/wcm/components/image/v3/image"
                         displayPopupTitle="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
                         isDecorative="true"
@@ -51,7 +51,7 @@
                         cq:styleIds="[1612896641947]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Subtitle"
-                        sling:resourceType="core/wcm/components/title/v2/title"
+                        sling:resourceType="core/wcm/components/title/v3/title"
                         type="h2">
                         <cq:responsive jcr:primaryType="nt:unstructured">
                             <default
@@ -92,7 +92,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
@@ -121,7 +121,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/de/article/sample-article-4/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/de/article/sample-article-4/.content.xml
@@ -8,7 +8,7 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Sample Article 4"
-        sling:resourceType="core/wcm/components/page/v2/page"
+        sling:resourceType="core/wcm/components/page/v3/page"
         socialMedia="[facebook,pinterest]">
         <root
             jcr:primaryType="nt:unstructured"
@@ -35,7 +35,7 @@
                         cq:styleIds="[1612913724665]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Symphony in Steel by Tobias Keller"
-                        sling:resourceType="core/wcm/components/image/v2/image"
+                        sling:resourceType="core/wcm/components/image/v3/image"
                         displayPopupTitle="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
                         isDecorative="true"
@@ -51,7 +51,7 @@
                         cq:styleIds="[1612896641947]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Subtitle"
-                        sling:resourceType="core/wcm/components/title/v2/title"
+                        sling:resourceType="core/wcm/components/title/v3/title"
                         type="h2">
                         <cq:responsive jcr:primaryType="nt:unstructured">
                             <default
@@ -92,7 +92,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
@@ -121,7 +121,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/de/contact-us/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/de/contact-us/.content.xml
@@ -7,7 +7,7 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Contact Us"
-        sling:resourceType="core/wcm/components/page/v2/page">
+        sling:resourceType="core/wcm/components/page/v3/page">
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="core/wcm/components/container/v1/container">
@@ -158,7 +158,7 @@
                         <title
                             jcr:primaryType="nt:unstructured"
                             jcr:title="Find us"
-                            sling:resourceType="core/wcm/components/title/v2/title"
+                            sling:resourceType="core/wcm/components/title/v3/title"
                             type="h4"/>
                         <text_1927678326
                             jcr:primaryType="nt:unstructured"
@@ -346,7 +346,7 @@
                         cq:styleIds="[1612896649188]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Find us"
-                        sling:resourceType="core/wcm/components/title/v2/title"
+                        sling:resourceType="core/wcm/components/title/v3/title"
                         type="h4"/>
                     <text
                         jcr:primaryType="nt:unstructured"
@@ -361,7 +361,7 @@
                         cq:styleIds="[1612896649188]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Need more help?"
-                        sling:resourceType="core/wcm/components/title/v2/title"
+                        sling:resourceType="core/wcm/components/title/v3/title"
                         type="h4"/>
                     <text_1226249202
                         jcr:primaryType="nt:unstructured"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/de/home/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/de/home/.content.xml
@@ -7,7 +7,7 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Home"
-        sling:resourceType="core/wcm/components/page/v2/page">
+        sling:resourceType="core/wcm/components/page/v3/page">
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="core/wcm/components/container/v1/container">
@@ -16,7 +16,7 @@
                 sling:resourceType="core/wcm/components/container/v1/container">
                 <title
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="core/wcm/components/title/v2/title"/>
+                    sling:resourceType="core/wcm/components/title/v3/title"/>
                 <container
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="core/wcm/components/container/v1/container"
@@ -25,7 +25,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/Image@2x.png"
@@ -52,7 +52,7 @@
                     <title
                         cq:styleIds="[1612896635178]"
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/title/v2/title"
+                        sling:resourceType="core/wcm/components/title/v3/title"
                         type="h2">
                         <cq:responsive jcr:primaryType="nt:unstructured">
                             <default
@@ -83,7 +83,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
@@ -112,7 +112,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/en/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/en/.content.xml
@@ -8,7 +8,7 @@
         cq:template="/conf/aem-site-template-standard/settings/wcm/templates/home-page"
         jcr:primaryType="cq:PageContent"
         jcr:title="English"
-        sling:resourceType="core/wcm/components/page/v2/page"
+        sling:resourceType="core/wcm/components/page/v3/page"
         facebookAppId="123456"
         pageTitle="My Site"
         socialMedia="[facebook,pinterest]">
@@ -21,7 +21,7 @@
                 sling:resourceType="core/wcm/components/container/v1/container">
                 <title
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="core/wcm/components/title/v2/title"/>
+                    sling:resourceType="core/wcm/components/title/v3/title"/>
                 <container
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="core/wcm/components/container/v1/container"
@@ -30,7 +30,7 @@
                         jcr:description="&lt;p>Don't stop half way, go for the top!&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Epic Journey"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="false"
                         descriptionFromPage="false"
                         textIsRich="true"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/en/article/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/en/article/.content.xml
@@ -6,7 +6,7 @@
         cq:template="/conf/aem-site-template-standard/settings/wcm/templates/article-page"
         jcr:primaryType="cq:PageContent"
         jcr:title="Article"
-        sling:resourceType="core/wcm/components/page/v2/page"
+        sling:resourceType="core/wcm/components/page/v3/page"
         socialMedia="[facebook,pinterest]">
         <root
             jcr:primaryType="nt:unstructured"
@@ -33,7 +33,7 @@
                         cq:styleIds="[1612913724665]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Symphony in Steel by Tobias Keller"
-                        sling:resourceType="core/wcm/components/image/v2/image"
+                        sling:resourceType="core/wcm/components/image/v3/image"
                         displayPopupTitle="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
                         isDecorative="true"
@@ -49,7 +49,7 @@
                         cq:styleIds="[1612896641947]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Subtitle"
-                        sling:resourceType="core/wcm/components/title/v2/title"
+                        sling:resourceType="core/wcm/components/title/v3/title"
                         type="h2">
                         <cq:responsive jcr:primaryType="nt:unstructured">
                             <default
@@ -90,7 +90,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
@@ -119,7 +119,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/en/article/sample-article-1/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/en/article/sample-article-1/.content.xml
@@ -8,7 +8,7 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Sample Article 1"
-        sling:resourceType="core/wcm/components/page/v2/page"
+        sling:resourceType="core/wcm/components/page/v3/page"
         socialMedia="[facebook,pinterest]">
         <root
             jcr:primaryType="nt:unstructured"
@@ -35,7 +35,7 @@
                         cq:styleIds="[1612913724665]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Symphony in Steel by Tobias Keller"
-                        sling:resourceType="core/wcm/components/image/v2/image"
+                        sling:resourceType="core/wcm/components/image/v3/image"
                         displayPopupTitle="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
                         isDecorative="true"
@@ -51,7 +51,7 @@
                         cq:styleIds="[1612896641947]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Subtitle"
-                        sling:resourceType="core/wcm/components/title/v2/title"
+                        sling:resourceType="core/wcm/components/title/v3/title"
                         type="h2">
                         <cq:responsive jcr:primaryType="nt:unstructured">
                             <default
@@ -92,7 +92,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
@@ -121,7 +121,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/en/article/sample-article-2/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/en/article/sample-article-2/.content.xml
@@ -8,7 +8,7 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Sample Article 2"
-        sling:resourceType="core/wcm/components/page/v2/page"
+        sling:resourceType="core/wcm/components/page/v3/page"
         socialMedia="[facebook,pinterest]">
         <root
             jcr:primaryType="nt:unstructured"
@@ -35,7 +35,7 @@
                         cq:styleIds="[1612913724665]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Symphony in Steel by Tobias Keller"
-                        sling:resourceType="core/wcm/components/image/v2/image"
+                        sling:resourceType="core/wcm/components/image/v3/image"
                         displayPopupTitle="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
                         isDecorative="true"
@@ -51,7 +51,7 @@
                         cq:styleIds="[1612896641947]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Subtitle"
-                        sling:resourceType="core/wcm/components/title/v2/title"
+                        sling:resourceType="core/wcm/components/title/v3/title"
                         type="h2">
                         <cq:responsive jcr:primaryType="nt:unstructured">
                             <default
@@ -92,7 +92,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
@@ -121,7 +121,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/en/article/sample-article-3/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/en/article/sample-article-3/.content.xml
@@ -8,7 +8,7 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Sample Article 3"
-        sling:resourceType="core/wcm/components/page/v2/page"
+        sling:resourceType="core/wcm/components/page/v3/page"
         socialMedia="[facebook,pinterest]">
         <root
             jcr:primaryType="nt:unstructured"
@@ -35,7 +35,7 @@
                         cq:styleIds="[1612913724665]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Symphony in Steel by Tobias Keller"
-                        sling:resourceType="core/wcm/components/image/v2/image"
+                        sling:resourceType="core/wcm/components/image/v3/image"
                         displayPopupTitle="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
                         isDecorative="true"
@@ -51,7 +51,7 @@
                         cq:styleIds="[1612896641947]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Subtitle"
-                        sling:resourceType="core/wcm/components/title/v2/title"
+                        sling:resourceType="core/wcm/components/title/v3/title"
                         type="h2">
                         <cq:responsive jcr:primaryType="nt:unstructured">
                             <default
@@ -92,7 +92,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
@@ -121,7 +121,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/en/article/sample-article-4/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/en/article/sample-article-4/.content.xml
@@ -8,7 +8,7 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Sample Article 4"
-        sling:resourceType="core/wcm/components/page/v2/page"
+        sling:resourceType="core/wcm/components/page/v3/page"
         socialMedia="[facebook,pinterest]">
         <root
             jcr:primaryType="nt:unstructured"
@@ -35,7 +35,7 @@
                         cq:styleIds="[1612913724665]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Symphony in Steel by Tobias Keller"
-                        sling:resourceType="core/wcm/components/image/v2/image"
+                        sling:resourceType="core/wcm/components/image/v3/image"
                         displayPopupTitle="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
                         isDecorative="true"
@@ -51,7 +51,7 @@
                         cq:styleIds="[1612896641947]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Subtitle"
-                        sling:resourceType="core/wcm/components/title/v2/title"
+                        sling:resourceType="core/wcm/components/title/v3/title"
                         type="h2">
                         <cq:responsive jcr:primaryType="nt:unstructured">
                             <default
@@ -92,7 +92,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
@@ -121,7 +121,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/en/contact-us/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/en/contact-us/.content.xml
@@ -7,7 +7,7 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Contact Us"
-        sling:resourceType="core/wcm/components/page/v2/page">
+        sling:resourceType="core/wcm/components/page/v3/page">
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="core/wcm/components/container/v1/container">
@@ -158,7 +158,7 @@
                         <title
                             jcr:primaryType="nt:unstructured"
                             jcr:title="Find us"
-                            sling:resourceType="core/wcm/components/title/v2/title"
+                            sling:resourceType="core/wcm/components/title/v3/title"
                             type="h4"/>
                         <text_1927678326
                             jcr:primaryType="nt:unstructured"
@@ -346,7 +346,7 @@
                         cq:styleIds="[1612896649188]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Find us"
-                        sling:resourceType="core/wcm/components/title/v2/title"
+                        sling:resourceType="core/wcm/components/title/v3/title"
                         type="h4"/>
                     <text
                         jcr:primaryType="nt:unstructured"
@@ -361,7 +361,7 @@
                         cq:styleIds="[1612896649188]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Need more help?"
-                        sling:resourceType="core/wcm/components/title/v2/title"
+                        sling:resourceType="core/wcm/components/title/v3/title"
                         type="h4"/>
                     <text_1226249202
                         jcr:primaryType="nt:unstructured"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/en/home/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/en/home/.content.xml
@@ -5,7 +5,7 @@
         cq:template="/conf/aem-site-template-standard/settings/wcm/templates/home-page"
         jcr:primaryType="cq:PageContent"
         jcr:title="Home"
-        sling:resourceType="core/wcm/components/page/v2/page">
+        sling:resourceType="core/wcm/components/page/v3/page">
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="core/wcm/components/container/v1/container">
@@ -14,7 +14,7 @@
                 sling:resourceType="core/wcm/components/container/v1/container">
                 <title
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="core/wcm/components/title/v2/title"/>
+                    sling:resourceType="core/wcm/components/title/v3/title"/>
                 <container
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="core/wcm/components/container/v1/container"
@@ -23,7 +23,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/Image@2x.png"
@@ -50,7 +50,7 @@
                     <title
                         cq:styleIds="[1612896635178]"
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/title/v2/title"
+                        sling:resourceType="core/wcm/components/title/v3/title"
                         type="h2">
                         <cq:responsive jcr:primaryType="nt:unstructured">
                             <default
@@ -81,7 +81,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
@@ -110,7 +110,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/.content.xml
@@ -12,7 +12,7 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="French"
-        sling:resourceType="core/wcm/components/page/v2/page"
+        sling:resourceType="core/wcm/components/page/v3/page"
         facebookAppId="123456"
         pageTitle="My Site"
         socialMedia="[facebook,pinterest]">
@@ -25,7 +25,7 @@
                 sling:resourceType="core/wcm/components/container/v1/container">
                 <title
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="core/wcm/components/title/v2/title"/>
+                    sling:resourceType="core/wcm/components/title/v3/title"/>
                 <container
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="core/wcm/components/container/v1/container"
@@ -34,7 +34,7 @@
                         jcr:description="&lt;p>Don't stop half way, go for the top!&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Epic Journey"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="false"
                         descriptionFromPage="false"
                         textIsRich="true"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/article/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/article/.content.xml
@@ -8,7 +8,7 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Article"
-        sling:resourceType="core/wcm/components/page/v2/page"
+        sling:resourceType="core/wcm/components/page/v3/page"
         socialMedia="[facebook,pinterest]">
         <root
             jcr:primaryType="nt:unstructured"
@@ -35,7 +35,7 @@
                         cq:styleIds="[1612913724665]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Symphony in Steel by Tobias Keller"
-                        sling:resourceType="core/wcm/components/image/v2/image"
+                        sling:resourceType="core/wcm/components/image/v3/image"
                         displayPopupTitle="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
                         isDecorative="true"
@@ -51,7 +51,7 @@
                         cq:styleIds="[1612896641947]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Subtitle"
-                        sling:resourceType="core/wcm/components/title/v2/title"
+                        sling:resourceType="core/wcm/components/title/v3/title"
                         type="h2">
                         <cq:responsive jcr:primaryType="nt:unstructured">
                             <default
@@ -92,7 +92,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
@@ -121,7 +121,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/article/sample-article-1/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/article/sample-article-1/.content.xml
@@ -8,7 +8,7 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Sample Article 1"
-        sling:resourceType="core/wcm/components/page/v2/page"
+        sling:resourceType="core/wcm/components/page/v3/page"
         socialMedia="[facebook,pinterest]">
         <root
             jcr:primaryType="nt:unstructured"
@@ -35,7 +35,7 @@
                         cq:styleIds="[1612913724665]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Symphony in Steel by Tobias Keller"
-                        sling:resourceType="core/wcm/components/image/v2/image"
+                        sling:resourceType="core/wcm/components/image/v3/image"
                         displayPopupTitle="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
                         isDecorative="true"
@@ -51,7 +51,7 @@
                         cq:styleIds="[1612896641947]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Subtitle"
-                        sling:resourceType="core/wcm/components/title/v2/title"
+                        sling:resourceType="core/wcm/components/title/v3/title"
                         type="h2">
                         <cq:responsive jcr:primaryType="nt:unstructured">
                             <default
@@ -92,7 +92,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
@@ -121,7 +121,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/article/sample-article-2/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/article/sample-article-2/.content.xml
@@ -8,7 +8,7 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Sample Article 2"
-        sling:resourceType="core/wcm/components/page/v2/page"
+        sling:resourceType="core/wcm/components/page/v3/page"
         socialMedia="[facebook,pinterest]">
         <root
             jcr:primaryType="nt:unstructured"
@@ -35,7 +35,7 @@
                         cq:styleIds="[1612913724665]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Symphony in Steel by Tobias Keller"
-                        sling:resourceType="core/wcm/components/image/v2/image"
+                        sling:resourceType="core/wcm/components/image/v3/image"
                         displayPopupTitle="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
                         isDecorative="true"
@@ -51,7 +51,7 @@
                         cq:styleIds="[1612896641947]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Subtitle"
-                        sling:resourceType="core/wcm/components/title/v2/title"
+                        sling:resourceType="core/wcm/components/title/v3/title"
                         type="h2">
                         <cq:responsive jcr:primaryType="nt:unstructured">
                             <default
@@ -92,7 +92,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
@@ -121,7 +121,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/article/sample-article-3/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/article/sample-article-3/.content.xml
@@ -8,7 +8,7 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Sample Article 3"
-        sling:resourceType="core/wcm/components/page/v2/page"
+        sling:resourceType="core/wcm/components/page/v3/page"
         socialMedia="[facebook,pinterest]">
         <root
             jcr:primaryType="nt:unstructured"
@@ -35,7 +35,7 @@
                         cq:styleIds="[1612913724665]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Symphony in Steel by Tobias Keller"
-                        sling:resourceType="core/wcm/components/image/v2/image"
+                        sling:resourceType="core/wcm/components/image/v3/image"
                         displayPopupTitle="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
                         isDecorative="true"
@@ -51,7 +51,7 @@
                         cq:styleIds="[1612896641947]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Subtitle"
-                        sling:resourceType="core/wcm/components/title/v2/title"
+                        sling:resourceType="core/wcm/components/title/v3/title"
                         type="h2">
                         <cq:responsive jcr:primaryType="nt:unstructured">
                             <default
@@ -92,7 +92,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
@@ -121,7 +121,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/article/sample-article-4/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/article/sample-article-4/.content.xml
@@ -8,7 +8,7 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Sample Article 4"
-        sling:resourceType="core/wcm/components/page/v2/page"
+        sling:resourceType="core/wcm/components/page/v3/page"
         socialMedia="[facebook,pinterest]">
         <root
             jcr:primaryType="nt:unstructured"
@@ -35,7 +35,7 @@
                         cq:styleIds="[1612913724665]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Symphony in Steel by Tobias Keller"
-                        sling:resourceType="core/wcm/components/image/v2/image"
+                        sling:resourceType="core/wcm/components/image/v3/image"
                         displayPopupTitle="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
                         isDecorative="true"
@@ -51,7 +51,7 @@
                         cq:styleIds="[1612896641947]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Subtitle"
-                        sling:resourceType="core/wcm/components/title/v2/title"
+                        sling:resourceType="core/wcm/components/title/v3/title"
                         type="h2">
                         <cq:responsive jcr:primaryType="nt:unstructured">
                             <default
@@ -92,7 +92,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
@@ -121,7 +121,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/contact-us/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/contact-us/.content.xml
@@ -7,7 +7,7 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Contact Us"
-        sling:resourceType="core/wcm/components/page/v2/page">
+        sling:resourceType="core/wcm/components/page/v3/page">
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="core/wcm/components/container/v1/container">
@@ -158,7 +158,7 @@
                         <title
                             jcr:primaryType="nt:unstructured"
                             jcr:title="Find us"
-                            sling:resourceType="core/wcm/components/title/v2/title"
+                            sling:resourceType="core/wcm/components/title/v3/title"
                             type="h4"/>
                         <text_1927678326
                             jcr:primaryType="nt:unstructured"
@@ -346,7 +346,7 @@
                         cq:styleIds="[1612896649188]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Find us"
-                        sling:resourceType="core/wcm/components/title/v2/title"
+                        sling:resourceType="core/wcm/components/title/v3/title"
                         type="h4"/>
                     <text
                         jcr:primaryType="nt:unstructured"
@@ -361,7 +361,7 @@
                         cq:styleIds="[1612896649188]"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="Need more help?"
-                        sling:resourceType="core/wcm/components/title/v2/title"
+                        sling:resourceType="core/wcm/components/title/v3/title"
                         type="h4"/>
                     <text_1226249202
                         jcr:primaryType="nt:unstructured"

--- a/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/home/.content.xml
+++ b/site/src/main/content/jcr_root/content/aem-site-template-standard/fr/home/.content.xml
@@ -7,7 +7,7 @@
         jcr:mixinTypes="[mix:versionable]"
         jcr:primaryType="cq:PageContent"
         jcr:title="Home"
-        sling:resourceType="core/wcm/components/page/v2/page">
+        sling:resourceType="core/wcm/components/page/v3/page">
         <root
             jcr:primaryType="nt:unstructured"
             sling:resourceType="core/wcm/components/container/v1/container">
@@ -16,7 +16,7 @@
                 sling:resourceType="core/wcm/components/container/v1/container">
                 <title
                     jcr:primaryType="nt:unstructured"
-                    sling:resourceType="core/wcm/components/title/v2/title"/>
+                    sling:resourceType="core/wcm/components/title/v3/title"/>
                 <container
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="core/wcm/components/container/v1/container"
@@ -25,7 +25,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/Image@2x.png"
@@ -52,7 +52,7 @@
                     <title
                         cq:styleIds="[1612896635178]"
                         jcr:primaryType="nt:unstructured"
-                        sling:resourceType="core/wcm/components/title/v2/title"
+                        sling:resourceType="core/wcm/components/title/v3/title"
                         type="h2">
                         <cq:responsive jcr:primaryType="nt:unstructured">
                             <default
@@ -83,7 +83,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"
@@ -112,7 +112,7 @@
                         jcr:description="&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.&lt;/p>&#xd;&#xa;"
                         jcr:primaryType="nt:unstructured"
                         jcr:title="This is a Teaser"
-                        sling:resourceType="core/wcm/components/teaser/v1/teaser"
+                        sling:resourceType="core/wcm/components/teaser/v2/teaser"
                         actionsEnabled="true"
                         descriptionFromPage="false"
                         fileReference="/content/dam/aem-site-template-standard/building_large.png"

--- a/site/src/main/content/jcr_root/content/experience-fragments/aem-site-template-standard/en/site/footer/master/.content.xml
+++ b/site/src/main/content/jcr_root/content/experience-fragments/aem-site-template-standard/en/site/footer/master/.content.xml
@@ -19,7 +19,7 @@
                 sling:resourceType="core/wcm/components/separator/v1/separator"/>
             <image
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="core/wcm/components/image/v2/image"
+                sling:resourceType="core/wcm/components/image/v3/image"
                 fileReference="/content/dam/aem-site-template-standard/Group 3458@2x.png">
                 <cq:responsive jcr:primaryType="nt:unstructured">
                     <default
@@ -36,7 +36,7 @@
                 cq:styleIds="[1612988098073]"
                 jcr:primaryType="nt:unstructured"
                 jcr:title="© Company Name Address Ave, City Name, State ZIP"
-                sling:resourceType="core/wcm/components/title/v2/title"
+                sling:resourceType="core/wcm/components/title/v3/title"
                 type="h6">
                 <cq:responsive jcr:primaryType="nt:unstructured">
                     <default

--- a/site/src/main/content/jcr_root/content/experience-fragments/aem-site-template-standard/en/site/header/master/.content.xml
+++ b/site/src/main/content/jcr_root/content/experience-fragments/aem-site-template-standard/en/site/header/master/.content.xml
@@ -16,7 +16,7 @@
             layout="responsiveGrid">
             <image
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="core/wcm/components/image/v2/image"
+                sling:resourceType="core/wcm/components/image/v3/image"
                 fileReference="/content/dam/aem-site-template-standard/Group 3458@2x.png">
                 <cq:responsive jcr:primaryType="nt:unstructured">
                     <default
@@ -27,7 +27,7 @@
             </image>
             <navigation
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="core/wcm/components/navigation/v1/navigation"
+                sling:resourceType="core/wcm/components/navigation/v2/navigation"
                 collectAllPages="true"
                 disableShadowing="false"
                 navigationRoot="/content/aem-site-template-standard/en"
@@ -52,7 +52,7 @@
             </search>
             <languagenavigation
                 jcr:primaryType="nt:unstructured"
-                sling:resourceType="core/wcm/components/languagenavigation/v1/languagenavigation"
+                sling:resourceType="core/wcm/components/languagenavigation/v2/languagenavigation"
                 navigationRoot="/content/aem-site-template-standard"
                 structureDepth="1">
                 <cq:responsive jcr:primaryType="nt:unstructured">

--- a/theme/src/components/teaser/_teaser_text_at_bottom.scss
+++ b/theme/src/components/teaser/_teaser_text_at_bottom.scss
@@ -45,6 +45,7 @@
     line-height: 2.25rem;
     text-align: start;
     text-decoration: none;
+    font-weight: 400;
   }
   .cmp-teaser__title-link {
     color: $color-text;

--- a/theme/src/components/teaser/_teaser_text_at_left.scss
+++ b/theme/src/components/teaser/_teaser_text_at_left.scss
@@ -44,6 +44,7 @@
     line-height: 2.25rem;
     text-align: start;
     text-decoration: none;
+    font-weight: 400;
   }
   .cmp-teaser__title-link {
     color: $color-text;

--- a/theme/src/components/teaser/_teaser_text_at_right.scss
+++ b/theme/src/components/teaser/_teaser_text_at_right.scss
@@ -42,6 +42,7 @@
     line-height: 2.25rem;
     text-align: start;
     text-decoration: none;
+    font-weight: 400;
   }
   .cmp-teaser__title-link {
     color: $color-text;


### PR DESCRIPTION
Updates standard-template to use the latest version of the core components.
The following components have new versions:
- Breadcrumb v3
- Button v2
- Content Fragment List v2
- Download v2
- Embed v2
- Experience Fragment v2
- Image v3
- Lang Nav v2
- List v3
- Navigation v2
- Page v3
- Teaser v2
- Title v3