### PR TITLE
Fix incorrect template path for Content Page

### DIFF
--- a/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/content-page/initial/.content.xml
+++ b/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/content-page/initial/.content.xml
@@ -2,7 +2,7 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:primaryType="cq:Page">
     <jcr:content
-        cq:template="/conf/aem-site-template-standard/settings/wcm/templates/article-page"
+        cq:template="/conf/aem-site-template-standard/settings/wcm/templates/content-page"
         jcr:primaryType="cq:PageContent"
         sling:resourceType="core/wcm/components/page/v3/page">
         <root

--- a/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/content-page/structure/.content.xml
+++ b/site/src/main/content/jcr_root/conf/aem-site-template-standard/settings/wcm/templates/content-page/structure/.content.xml
@@ -3,7 +3,7 @@
     jcr:primaryType="cq:Page">
     <jcr:content
         cq:deviceGroups="[mobile/groups/responsive]"
-        cq:template="/conf/aem-site-template-standard/settings/wcm/templates/article-page"
+        cq:template="/conf/aem-site-template-standard/settings/wcm/templates/content-page"
         jcr:primaryType="cq:PageContent"
         sling:resourceType="core/wcm/components/page/v3/page">
         <root


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## The Content Page has the incorrect template path

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/adobe/aem-site-template-standard/issues/90

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?


<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
