### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/release-stub.yml
+++ b/.github/workflows/release-stub.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Extract name and version from package.json
         id: packageJson
         run: |
-          echo ::set-output name=NAME::$(echo '${{ steps.package.outputs.content }}' | jq -r '.name')
-          echo ::set-output name=VERSION::$(echo '${{ steps.package.outputs.content }}' | jq -r '.version')
+          echo "NAME=$(echo '${{ steps.package.outputs.content }}' | jq -r '.name')" >> $GITHUB_OUTPUT
+          echo "VERSION=$(echo '${{ steps.package.outputs.content }}' | jq -r '.version')" >> $GITHUB_OUTPUT
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,8 @@ jobs:
       - name: Extract name and version from package.json
         id: packageJson
         run: |
-          echo ::set-output name=NAME::$(echo '${{ steps.package.outputs.content }}' | jq -r '.name')
-          echo ::set-output name=VERSION::$(echo '${{ steps.package.outputs.content }}' | jq -r '.version')
+          echo "NAME=$(echo '${{ steps.package.outputs.content }}' | jq -r '.name')" >> $GITHUB_OUTPUT
+          echo "VERSION=$(echo '${{ steps.package.outputs.content }}' | jq -r '.version')" >> $GITHUB_OUTPUT
 
       - name: Create Release
         id: create_release


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter