### PR TITLE
replaced hard-coded children with :has(ul)

### DIFF
--- a/theme/src/components/navigation/_navigation.scss
+++ b/theme/src/components/navigation/_navigation.scss
@@ -48,7 +48,7 @@
     transition-delay: 0.5s;
   }
 }
-.cmp-navigation__item--level-0:nth-child(2) {
+.cmp-navigation__item--level-0:has(ul) {
   &:after {
     display: inline-block;
     width: 24px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes issue: 107
https://github.com/adobe/aem-site-template-standard/issues/107


<!--- Describe your changes in detail -->

The main nav shows one dropdown item that is hardcoded in the CSS to only allow the second child to have a dropdown. By changing the selector to :has(ul) it shows the dropdown for any nav item that has children
## Related Issue

https://github.com/adobe/aem-site-template-standard/issues/107

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The main nav can only have one dropdown as it is, that is the second child. This fixes it so any item can have a dropdown.

## How Has This Been Tested?

I tested only on my own instance with a site derived from this template.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
